### PR TITLE
ShogiLibSharp.Engine のいくつかの修正

### DIFF
--- a/ShogiLibSharp.Engine/Process/IEngineProcess.cs
+++ b/ShogiLibSharp.Engine/Process/IEngineProcess.cs
@@ -9,6 +9,8 @@ namespace ShogiLibSharp.Engine.Process
 {
     internal interface IEngineProcess : IDisposable
     {
+        bool HasExited { get; }
+
         event Action<string?>? StdOutReceived;
         event Action<string?>? StdErrReceived;
         event EventHandler Exited;
@@ -17,5 +19,6 @@ namespace ShogiLibSharp.Engine.Process
         void BeginErrorReadLine();
         void SendLine(string message);
         void Kill();
+        Task WaitForExitAsync(CancellationToken ct = default);
     }
 }

--- a/ShogiLibSharp.Engine/SearchResult.cs
+++ b/ShogiLibSharp.Engine/SearchResult.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using ShogiLibSharp.Core;
 
-namespace ShogiLibSharp.Engine.States
+namespace ShogiLibSharp.Engine
 {
     public record SearchResult(Move Bestmove, Move Ponder, List<UsiInfo> InfoList);
 }

--- a/Tests/ShogiLibSharp.Engine.Tests/RandomPlayer.cs
+++ b/Tests/ShogiLibSharp.Engine.Tests/RandomPlayer.cs
@@ -11,10 +11,12 @@ namespace ShogiLibSharp.Engine.Tests
 {
     internal class RandomPlayer : IEngineProcess
     {
-        private Core.Position? pos = null;
+        private Position? pos = null;
         private Random rnd = new(0);
         private TaskCompletionSource? tcsGo = null;
         private TaskCompletionSource? tcsPonder = null;
+
+        public bool HasExited => true;
 
         public event Action<string?>? StdOutReceived;
         public event Action<string?>? StdErrReceived;
@@ -135,6 +137,11 @@ namespace ShogiLibSharp.Engine.Tests
         public bool Start()
         {
             return true;
+        }
+
+        public Task WaitForExitAsync(CancellationToken ct = default)
+        {
+            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
* Dispose を DisposeAsync に変更し、プロセスの終了もするように変更
* IsReadyAsync, GoAsync などで、呼ぶ前にキャンセルされていたらキャンセル例外をスローに変更
* CreateNoWindow を true に
* Writer.Complete() の後に WriteAsync が呼ばれるケースがあったのを修正